### PR TITLE
fix: function expand in tensor.py

### DIFF
--- a/minitorch/tensor.py
+++ b/minitorch/tensor.py
@@ -209,6 +209,7 @@ class Tensor(Variable):
             if orig_shape[dim] == 1 and shape != 1:
                 out = self.backend._add_reduce(out, dim)
         assert out.size == self.size, f"{out.shape} {self.shape}"
+        out=Tensor.make(out._tensor._storage, self.shape, backend=self.backend)
         return out
 
     def zeros(self, shape=None):


### PR DESCRIPTION
According to Pytorch, we should delete the extra dimensions in the beginning with size 1 to make the shape of the gradient exactly equal that of the input. 