### PR TITLE
tensor_functions: Expand the backward result of Add

### DIFF
--- a/minitorch/tensor_functions.py
+++ b/minitorch/tensor_functions.py
@@ -88,11 +88,13 @@ def make_tensor_backend(tensor_ops, is_cuda=False):
         class Add(Function):
             @staticmethod
             def forward(ctx, t1, t2):
+                ctx.save_for_backward(t1, t2)
                 return add_zip(t1, t2)
 
             @staticmethod
             def backward(ctx, grad_output):
-                return grad_output, grad_output
+                t1, t2 = ctx.saved_values
+                return t1.expand(grad_output), t2.expand(grad_output)
 
         class Mul(Function):
             @staticmethod


### PR DESCRIPTION
(This PR is a duplicate of https://github.com/minitorch/minitorch/pull/1 on the main `minitorch` repository. If this is not the right way to contribute, then writing some contribution guidelines somewhere would be helpful.)

## Description

The provided `Add` class does not pass the tests since we need to `expand()` `grad_output` to handle broadcasting.

This PR adds `expand()` to the Add function.

(If it was actually intentional for `expand()` to not be used, then we should instead add TODOs in `Add` to notify the students that `Add` needs to be fixed. We should then also mention `expand()` in the docs—it's really not obvious that students need to use this `expand()` function that was not mentioned anywhere.)

